### PR TITLE
Missing pip dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
 - python=3.6
 - pytorch=1.4.0
 - scipy
+- pip
 - pip:
   - dominate==2.4.0
   - torchvision==0.5.0


### PR DESCRIPTION
Results in a warning when trying to create a Conda environment as pip-installed dependencies are listed in the environment file, but not pip itself.