### PR TITLE
Support batch_size >= 2 testing, fakeA is also outputted in the result file and index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The checkpoints will be stored at `./checkpoints/grumpycat_*/web`.
 
 - Test the CUT model:
 ```bash
-python test.py --dataroot ./datasets/grumpifycat --name grumpycat_CUT --CUT_mode CUT --phase train
+python test.py --dataroot ./datasets/grumpifycat --name grumpycat_CUT --CUT_mode CUT --phase test
 ```
 
 The test results will be saved to a html file here: `./results/grumpifycat/latest_train/index.html`.

--- a/models/cut_model.py
+++ b/models/cut_model.py
@@ -59,7 +59,7 @@ class CUTModel(BaseModel):
         # specify the training losses you want to print out.
         # The training/test scripts will call <BaseModel.get_current_losses>
         self.loss_names = ['G_GAN', 'D_real', 'D_fake', 'G', 'NCE']
-        self.visual_names = ['real_A', 'fake_B', 'real_B']
+        self.visual_names = ['real_A', 'fake_B', 'real_B', 'fake_A']
         self.nce_layers = [int(i) for i in self.opt.nce_layers.split(',')]
 
         if opt.nce_idt and self.isTrain:
@@ -141,7 +141,7 @@ class CUTModel(BaseModel):
         AtoB = self.opt.direction == 'AtoB'
         self.real_A = input['A' if AtoB else 'B'].to(self.device)
         self.real_B = input['B' if AtoB else 'A'].to(self.device)
-        self.image_paths = input['A_paths' if AtoB else 'B_paths']
+        self.image_paths = input['A_paths'] + input['B_paths']
 
     def forward(self):
         """Run forward pass; called by both functions <optimize_parameters> and <test>."""
@@ -155,6 +155,11 @@ class CUTModel(BaseModel):
         self.fake_B = self.fake[:self.real_A.size(0)]
         if self.opt.nce_idt:
             self.idt_B = self.fake[self.real_A.size(0):]
+            
+        self.fake = self.netG(self.real_B)
+        self.fake_A = self.fake[:self.real_B.size(0)]
+        if self.opt.nce_idt:
+            self.idt_A = self.fake[self.real_B.size(0):]
 
     def compute_D_loss(self):
         """Calculate GAN loss for the discriminator"""

--- a/util/visualizer.py
+++ b/util/visualizer.py
@@ -25,22 +25,61 @@ def save_images(webpage, visuals, image_path, aspect_ratio=1.0, width=256):
     This function will save images stored in 'visuals' to the HTML file specified by 'webpage'.
     """
     image_dir = webpage.get_image_dir()
-    short_path = ntpath.basename(image_path[0])
-    name = os.path.splitext(short_path)[0]
+    short_path = [ntpath.basename(p) for p in image_path]
+    name = [os.path.splitext(p)[0] for p in short_path]
 
-    webpage.add_header(name)
-    ims, txts, links = [], [], []
-
-    for label, im_data in visuals.items():
-        im = util.tensor2im(im_data)
-        image_name = '%s/%s.png' % (label, name)
-        os.makedirs(os.path.join(image_dir, label), exist_ok=True)
+    real_A = visuals['real_A']
+    fake_B = visuals['fake_B']
+    real_B = visuals['real_B']
+    fake_A = visuals['fake_A']
+    
+    batch_size = len(name) // 2
+    for idx, (r_A_im_b, r_B_im_b) in enumerate(zip(real_A, real_B)):
+        r_A_n_b = name[idx]
+        r_B_n_b = name[idx + batch_size]
+        ims, txts, links = [], [], []
+        webpage.add_header(r_A_n_b)
+        r_A_im = util.tensor2im(r_A_im_b.unsqueeze(0))
+        image_name = '%s/%s.png' % ('real_A', r_A_n_b)
+        os.makedirs(os.path.join(image_dir, 'real_A'), exist_ok=True)
         save_path = os.path.join(image_dir, image_name)
-        util.save_image(im, save_path, aspect_ratio=aspect_ratio)
+        util.save_image(r_A_im, save_path, aspect_ratio=aspect_ratio)
         ims.append(image_name)
-        txts.append(label)
+        txts.append('real_A')
         links.append(image_name)
-    webpage.add_images(ims, txts, links, width=width)
+        
+        f_B_im = util.tensor2im(fake_B[idx].unsqueeze(0))
+        image_name = '%s/%s.png' % ('fake_B', r_A_n_b)
+        os.makedirs(os.path.join(image_dir, 'fake_B'), exist_ok=True)
+        save_path = os.path.join(image_dir, image_name)
+        util.save_image(f_B_im, save_path, aspect_ratio=aspect_ratio)
+        ims.append(image_name)
+        txts.append('fake_B')
+        links.append(image_name)
+        
+        webpage.add_images(ims, txts, links, width=width)
+        ims, txts, links = [], [], []
+            
+        webpage.add_header(r_B_n_b)
+        r_B_im = util.tensor2im(r_B_im_b.unsqueeze(0))
+        image_name = '%s/%s.png' % ('real_B', r_B_n_b)
+        os.makedirs(os.path.join(image_dir, 'real_B'), exist_ok=True)
+        save_path = os.path.join(image_dir, image_name)
+        util.save_image(r_B_im, save_path, aspect_ratio=aspect_ratio)
+        ims.append(image_name)
+        txts.append('real_B')
+        links.append(image_name)
+        
+        f_A_im = util.tensor2im(fake_A[idx].unsqueeze(0))
+        image_name = '%s/%s.png' % ('fake_A', r_B_n_b)
+        os.makedirs(os.path.join(image_dir, 'fake_A'), exist_ok=True)
+        save_path = os.path.join(image_dir, image_name)
+        util.save_image(f_A_im, save_path, aspect_ratio=aspect_ratio)
+        ims.append(image_name)
+        txts.append('fake_A')
+        links.append(image_name)
+        
+        webpage.add_images(ims, txts, links, width=width)
 
 
 class Visualizer():


### PR DESCRIPTION
This commit solves the #126 and the restriction of only support batch_size=1 in test.py. More, details:
- A to B and B to A outputs are both available in the result file. Index.html is compatible accordingly.
- To accelerate the testing speed and original restriction in test.py, batch_size>=2 is supported (multiple GPU inference is supported). The outputs are verified correctly.
- Additionally, the arg of '--phase' should be 'test' in the test command in README.
Any questions are appreciated ^-^