### PR TITLE
minor bug in calculating nce loss

### DIFF
--- a/models/cut_model.py
+++ b/models/cut_model.py
@@ -211,4 +211,4 @@ class CUTModel(BaseModel):
             loss = crit(f_q, f_k) * self.opt.lambda_NCE
             total_nce_loss += loss.mean()
 
-        return total_nce_loss / n_layers
+        return total_nce_loss / len(feat_q)


### PR DESCRIPTION
`self.nce_layers` is initialized to `[0,2,4]` by default. While when using `smallgan2` as generator there is no any feature coming from 4th layer. The patches are only coming from `[0,2]` in this situation.