### PR TITLE
Remove unused `train_dataset`

### DIFF
--- a/test.py
+++ b/test.py
@@ -44,7 +44,6 @@ if __name__ == '__main__':
     opt.no_flip = True    # no flip; comment this line if results on flipped images are needed.
     opt.display_id = -1   # no visdom display; the test code saves the results to a HTML file.
     dataset = create_dataset(opt)  # create a dataset given opt.dataset_mode and other options
-    train_dataset = create_dataset(util.copyconf(opt, phase="train"))
     model = create_model(opt)      # create a model given opt.model and other options
     # create a webpage for viewing the results
     web_dir = os.path.join(opt.results_dir, opt.name, '{}_{}'.format(opt.phase, opt.epoch))  # define the website directory


### PR DESCRIPTION
The dataset `train_dataset` is unused in the test script. If this line is not removed, the dataset used for testing is required to have a `trainA` and `trainB` directory, which might not be the case for pure testing datasets. Thus it should be removed.